### PR TITLE
Lower case JSON keys

### DIFF
--- a/hive-serdes/src/main/java/com/cloudera/hive/serde/JSONSerDe.java
+++ b/hive-serdes/src/main/java/com/cloudera/hive/serde/JSONSerDe.java
@@ -127,6 +127,13 @@ public class JSONSerDe implements SerDe {
     } catch (Exception e) {
       throw new SerDeException(e);
     }
+
+    // Lowercase the keys as expected by hive
+    Map<String, Object> lowerRoot = new HashMap();
+    for(Map.Entry entry: root.entrySet()) {
+      lowerRoot.put(((String)entry.getKey()).toLowerCase(), entry.getValue());
+    }
+    root = lowerRoot;
     
     Object value= null;
     for (String fieldName : rowTypeInfo.getAllStructFieldNames()) {


### PR DESCRIPTION
HIVE seems to be internally lower casing all columns names even though when they are properly escaped during table creation:

hive> create table xxxx(`DeviceID` string); 
OK 
Time taken: 0.229 seconds 
hive> describe xxxx; 
OK 
deviceid string 
Time taken: 0.128 seconds

I'm attaching simple patch that will automatically lowercase all keys in the input JSON, so that the SerDe will work on keys that are not lower cased. SerDe with this patch might behave unpredictable if the input JSON have multiple columns that have same lower cased form (for example "DevideId" and "deviceId").
