### PR TITLE
Fix keywords size when keywordString is empty

### DIFF
--- a/flume-sources/src/main/java/com/cloudera/flume/source/TwitterSource.java
+++ b/flume-sources/src/main/java/com/cloudera/flume/source/TwitterSource.java
@@ -77,9 +77,14 @@ public class TwitterSource extends AbstractSource
     accessTokenSecret = context.getString(TwitterSourceConstants.ACCESS_TOKEN_SECRET_KEY);
 
     String keywordString = context.getString(TwitterSourceConstants.KEYWORDS_KEY, "");
-    keywords = keywordString.split(",");
-    for (int i = 0; i < keywords.length; i++) {
-      keywords[i] = keywords[i].trim();
+    if (keywordString.lenght() > 0) {
+	keywords = keywordString.split(",");
+	for (int i = 0; i < keywords.length; i++) {
+	    keywords[i] = keywords[i].trim();
+	}
+    }
+    else {
+	keywords = new String[0];
     }
 
     ConfigurationBuilder cb = new ConfigurationBuilder();


### PR DESCRIPTION
Hi, 
If I set `TwitterAgent.sources.Twitter.keywords =`
the actual implementation will still try to use `twitterStream.filter()` instead of `twitterStream.sample()`.
The if/else statement is here to fix this little problem.
