### PR TITLE
Addressing flume twitter source to work properly for Sampling

### DIFF
--- a/flume-sources/src/main/java/com/cloudera/flume/source/TwitterSource.java
+++ b/flume-sources/src/main/java/com/cloudera/flume/source/TwitterSource.java
@@ -77,9 +77,13 @@ public class TwitterSource extends AbstractSource
     accessTokenSecret = context.getString(TwitterSourceConstants.ACCESS_TOKEN_SECRET_KEY);
 
     String keywordString = context.getString(TwitterSourceConstants.KEYWORDS_KEY, "");
-    keywords = keywordString.split(",");
-    for (int i = 0; i < keywords.length; i++) {
-      keywords[i] = keywords[i].trim();
+    if (keywordString.trim().length() == 0) {
+        keywords = new String[0];
+    } else {
+      keywords = keywordString.split(",");
+      for (int i = 0; i < keywords.length; i++) {
+        keywords[i] = keywords[i].trim();
+      }
     }
 
     ConfigurationBuilder cb = new ConfigurationBuilder();


### PR DESCRIPTION
Based on the existing code, if a user doesn't supply the TwitterSourceConstants.KEYWORDS_KEY property (then it is intended to use twitter sampling instead of filtering). But, the exsiting code will still run filtering as

String keywordString = "";
String[] keywords = keywordString.split(",");
The result of the above statement is an array of size 1, which is not expected based on the implementation of code.
