### PR TITLE
Hive SQL can not handle keys with dot or minus

### DIFF
--- a/hive-serdes/pom.xml
+++ b/hive-serdes/pom.xml
@@ -91,6 +91,11 @@
       <artifactId>jackson-core-asl</artifactId>
       <version>1.9.8</version>
     </dependency>
+    <dependency>
+	  <groupId>org.codehaus.jackson</groupId>
+	  <artifactId>jackson-mapper-asl</artifactId>
+      <version>1.9.8</version>
+    </dependency>
 
     <!-- Hadoop Dependencies -->
     <dependency>

--- a/hive-serdes/pom.xml
+++ b/hive-serdes/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>com.cloudera.serde</groupId>
   <artifactId>hive-serdes</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>hive-serdes</name>

--- a/hive-serdes/src/main/java/com/cloudera/hive/serde/JSONSerDe.java
+++ b/hive-serdes/src/main/java/com/cloudera/hive/serde/JSONSerDe.java
@@ -73,314 +73,317 @@ import org.codehaus.jackson.map.ObjectMapper;
  * Only STRING keys are supported for Hive MAPs.
  */
 public class JSONSerDe implements SerDe {
-  
-  private StructTypeInfo rowTypeInfo;
-  private ObjectInspector rowOI;
-  private List<String> colNames;
-  private List<Object> row = new ArrayList<Object>();
-  
-  /**
-   * An initialization function used to gather information about the table.
-   * Typically, a SerDe implementation will be interested in the list of
-   * column names and their types. That information will be used to help perform
-   * actual serialization and deserialization of data.
-   */
-  @Override
-  public void initialize(Configuration conf, Properties tbl)
-      throws SerDeException {
-    // Get a list of the table's column names.
-    String colNamesStr = tbl.getProperty(serdeConstants.LIST_COLUMNS);
-    colNames = Arrays.asList(colNamesStr.split(","));
-    
-    // Get a list of TypeInfos for the columns. This list lines up with
-    // the list of column names.
-    String colTypesStr = tbl.getProperty(serdeConstants.LIST_COLUMN_TYPES);
-    List<TypeInfo> colTypes =
-        TypeInfoUtils.getTypeInfosFromTypeString(colTypesStr);
-    
-    rowTypeInfo =
-        (StructTypeInfo) TypeInfoFactory.getStructTypeInfo(colNames, colTypes);
-    rowOI =
-        TypeInfoUtils.getStandardJavaObjectInspectorFromTypeInfo(rowTypeInfo);
-  }
 
-  /**
-   * This method does the work of deserializing a record into Java objects that
-   * Hive can work with via the ObjectInspector interface. For this SerDe, the
-   * blob that is passed in is a JSON string, and the Jackson JSON parser is
-   * being used to translate the string into Java objects.
-   * 
-   * The JSON deserialization works by taking the column names in the Hive
-   * table, and looking up those fields in the parsed JSON object. If the value
-   * of the field is not a primitive, the object is parsed further.
-   */
-  @Override
-  public Object deserialize(Writable blob) throws SerDeException {
-    Map<?,?> root = null;
-    row.clear();
-    try {
-      ObjectMapper mapper = new ObjectMapper();
-      // This is really a Map<String, Object>. For more information about how
-      // Jackson parses JSON in this example, see
-      // http://wiki.fasterxml.com/JacksonDataBinding
-      root = mapper.readValue(blob.toString(), Map.class);
-    } catch (Exception e) {
-      throw new SerDeException(e);
+    private StructTypeInfo rowTypeInfo;
+    private ObjectInspector rowOI;
+    private List<String> colNames;
+    private List<Object> row = new ArrayList<Object>();
+
+    /**
+     * An initialization function used to gather information about the table.
+     * Typically, a SerDe implementation will be interested in the list of
+     * column names and their types. That information will be used to help perform
+     * actual serialization and deserialization of data.
+     */
+    @Override
+    public void initialize(Configuration conf, Properties tbl)
+            throws SerDeException {
+        // Get a list of the table's column names.
+        String colNamesStr = tbl.getProperty(serdeConstants.LIST_COLUMNS);
+        colNames = Arrays.asList(colNamesStr.split(","));
+
+        // Get a list of TypeInfos for the columns. This list lines up with
+        // the list of column names.
+        String colTypesStr = tbl.getProperty(serdeConstants.LIST_COLUMN_TYPES);
+        List<TypeInfo> colTypes =
+                TypeInfoUtils.getTypeInfosFromTypeString(colTypesStr);
+
+        rowTypeInfo =
+                (StructTypeInfo) TypeInfoFactory.getStructTypeInfo(colNames, colTypes);
+        rowOI =
+                TypeInfoUtils.getStandardJavaObjectInspectorFromTypeInfo(rowTypeInfo);
     }
 
-    // Lowercase the keys as expected by hive
-    Map<String, Object> lowerRoot = new HashMap();
-    for(Map.Entry entry: root.entrySet()) {
-      lowerRoot.put(((String)entry.getKey()).toLowerCase(), entry.getValue());
-    }
-    root = lowerRoot;
-    
-    Object value= null;
-    for (String fieldName : rowTypeInfo.getAllStructFieldNames()) {
-      try {
-        TypeInfo fieldTypeInfo = rowTypeInfo.getStructFieldTypeInfo(fieldName);
-        value = parseField(root.get(fieldName), fieldTypeInfo);
-      } catch (Exception e) {
-        value = null;
-      }
-      row.add(value);
-    }
-    return row;
-  }
-  
-  /**
-   * Parses a JSON object according to the Hive column's type.
-   * 
-   * @param field - The JSON object to parse
-   * @param fieldTypeInfo - Metadata about the Hive column
-   * @return - The parsed value of the field
-   */
-  private Object parseField(Object field, TypeInfo fieldTypeInfo) {
-    switch (fieldTypeInfo.getCategory()) {
-    case PRIMITIVE:
-      // Jackson will return the right thing in this case, so just return
-      // the object
-      if (field instanceof String) {
-        field = field.toString().replaceAll("\n", "\\\\n");
-      }
-      return field;
-    case LIST:
-      return parseList(field, (ListTypeInfo) fieldTypeInfo);
-    case MAP:
-      return parseMap(field, (MapTypeInfo) fieldTypeInfo);
-    case STRUCT:
-      return parseStruct(field, (StructTypeInfo) fieldTypeInfo);
-    case UNION:
-      // Unsupported by JSON
-    default:
-      return null;
-    }
-  }
-  
-  /**
-   * Parses a JSON object and its fields. The Hive metadata is used to
-   * determine how to parse the object fields.
-   * 
-   * @param field - The JSON object to parse
-   * @param fieldTypeInfo - Metadata about the Hive column
-   * @return - A map representing the object and its fields
-   */
-  private Object parseStruct(Object field, StructTypeInfo fieldTypeInfo) {
-    Map<Object,Object> map = (Map<Object,Object>)field;
-    ArrayList<TypeInfo> structTypes = fieldTypeInfo.getAllStructFieldTypeInfos();
-    ArrayList<String> structNames = fieldTypeInfo.getAllStructFieldNames();
-    
-    List<Object> structRow = new ArrayList<Object>(structTypes.size());
-    for (int i = 0; i < structNames.size(); i++) {
-      structRow.add(parseField(map.get(structNames.get(i)), structTypes.get(i)));
-    }
-    return structRow;
-  }
+    /**
+     * This method does the work of deserializing a record into Java objects that
+     * Hive can work with via the ObjectInspector interface. For this SerDe, the
+     * blob that is passed in is a JSON string, and the Jackson JSON parser is
+     * being used to translate the string into Java objects.
+     * 
+     * The JSON deserialization works by taking the column names in the Hive
+     * table, and looking up those fields in the parsed JSON object. If the value
+     * of the field is not a primitive, the object is parsed further.
+     */
+    @Override
+    public Object deserialize(Writable blob) throws SerDeException {
+        Map<?, ?> root = null;
+        row.clear();
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            // This is really a Map<String, Object>. For more information about how
+            // Jackson parses JSON in this example, see
+            // http://wiki.fasterxml.com/JacksonDataBinding
+            root = mapper.readValue(blob.toString(), Map.class);
+        } catch (Exception e) {
+            throw new SerDeException(e);
+        }
 
-  /**
-   * Parse a JSON list and its elements. This uses the Hive metadata for the
-   * list elements to determine how to parse the elements.
-   * 
-   * @param field - The JSON list to parse
-   * @param fieldTypeInfo - Metadata about the Hive column
-   * @return - A list of the parsed elements
-   */
-  private Object parseList(Object field, ListTypeInfo fieldTypeInfo) {
-    ArrayList<Object> list = (ArrayList<Object>) field;
-    TypeInfo elemTypeInfo = fieldTypeInfo.getListElementTypeInfo();
-    
-    for (int i = 0; i < list.size(); i++) {
-      list.set(i, parseField(list.get(i), elemTypeInfo));
+        // Lowercase the keys as expected by hive
+        Map<String, Object> lowerRoot = new HashMap<String, Object>();
+        for (Map.Entry<?, ?> entry : root.entrySet()) {
+            lowerRoot.put(((String) entry.getKey()).toLowerCase(), entry.getValue());
+        }
+        root = lowerRoot;
+
+        Object value = null;
+        for (String fieldName : rowTypeInfo.getAllStructFieldNames()) {
+            try {
+                TypeInfo fieldTypeInfo = rowTypeInfo.getStructFieldTypeInfo(fieldName);
+                value = parseField(root.get(fieldName), fieldTypeInfo);
+            } catch (Exception e) {
+                value = null;
+            }
+            row.add(value);
+        }
+        return row;
     }
-    
-    return list.toArray();
-  }
 
-  /**
-   * Parse a JSON object as a map. This uses the Hive metadata for the map
-   * values to determine how to parse the values. The map is assumed to have
-   * a string for a key.
-   * 
-   * @param field - The JSON list to parse
-   * @param fieldTypeInfo - Metadata about the Hive column
-   * @return
-   */
-  private Object parseMap(Object field, MapTypeInfo fieldTypeInfo) {
-    Map<Object,Object> map = (Map<Object,Object>) field;
-    TypeInfo valueTypeInfo = fieldTypeInfo.getMapValueTypeInfo();
-    
-    for (Map.Entry<Object,Object> entry : map.entrySet()) {
-      map.put(entry.getKey(), parseField(entry.getValue(), valueTypeInfo));
+    /**
+     * Parses a JSON object according to the Hive column's type.
+     * 
+     * @param field - The JSON object to parse
+     * @param fieldTypeInfo - Metadata about the Hive column
+     * @return - The parsed value of the field
+     */
+    private Object parseField(Object field, TypeInfo fieldTypeInfo) {
+        switch (fieldTypeInfo.getCategory()) {
+            case PRIMITIVE:
+                // Jackson will return the right thing in this case, so just return
+                // the object
+                if (field instanceof String) {
+                    field = field.toString().replaceAll("\n", "\\\\n");
+                }
+                return field;
+            case LIST:
+                return parseList(field, (ListTypeInfo) fieldTypeInfo);
+            case MAP:
+                return parseMap(field, (MapTypeInfo) fieldTypeInfo);
+            case STRUCT:
+                return parseStruct(field, (StructTypeInfo) fieldTypeInfo);
+            case UNION:
+                // Unsupported by JSON
+            default:
+                return null;
+        }
     }
-    return map;
-  }
 
-  /**
-   * Return an ObjectInspector for the row of data
-   */
-  @Override
-  public ObjectInspector getObjectInspector() throws SerDeException {
-    return rowOI;
-  }
+    /**
+     * Parses a JSON object and its fields. The Hive metadata is used to
+     * determine how to parse the object fields.
+     * 
+     * @param field - The JSON object to parse
+     * @param fieldTypeInfo - Metadata about the Hive column
+     * @return - A map representing the object and its fields
+     */
+    private Object parseStruct(Object field, StructTypeInfo fieldTypeInfo) {
+        @SuppressWarnings("unchecked")
+        Map<Object, Object> map = (Map<Object, Object>) field;
+        ArrayList<TypeInfo> structTypes = fieldTypeInfo.getAllStructFieldTypeInfos();
+        ArrayList<String> structNames = fieldTypeInfo.getAllStructFieldNames();
 
-  /**
-   * Unimplemented
-   */
-  @Override
-  public SerDeStats getSerDeStats() {
-    return null;
-  }
-
-  /**
-   * JSON is just a textual representation, so our serialized class
-   * is just Text.
-   */
-  @Override
-  public Class<? extends Writable> getSerializedClass() {
-    return Text.class;
-  }
-
-  /**
-   * This method takes an object representing a row of data from Hive, and uses
-   * the ObjectInspector to get the data for each column and serialize it. This
-   * implementation deparses the row into an object that Jackson can easily
-   * serialize into a JSON blob.
-   */
-  @Override
-  public Writable serialize(Object obj, ObjectInspector oi)
-      throws SerDeException {
-    Object deparsedObj = deparseRow(obj, oi);
-    ObjectMapper mapper = new ObjectMapper();
-    try {
-      // Let Jackson do the work of serializing the object
-      return new Text(mapper.writeValueAsString(deparsedObj));
-    } catch (Exception e) {
-      throw new SerDeException(e);
+        List<Object> structRow = new ArrayList<Object>(structTypes.size());
+        for (int i = 0; i < structNames.size(); i++) {
+            structRow.add(parseField(map.get(structNames.get(i)), structTypes.get(i)));
+        }
+        return structRow;
     }
-  }
 
-  /**
-   * Deparse a Hive object into a Jackson-serializable object. This uses
-   * the ObjectInspector to extract the column data.
-   * 
-   * @param obj - Hive object to deparse
-   * @param oi - ObjectInspector for the object
-   * @return - A deparsed object
-   */
-  private Object deparseObject(Object obj, ObjectInspector oi) {
-    switch (oi.getCategory()) {
-    case LIST:
-      return deparseList(obj, (ListObjectInspector)oi);
-    case MAP:
-      return deparseMap(obj, (MapObjectInspector)oi);
-    case PRIMITIVE:
-      return deparsePrimitive(obj, (PrimitiveObjectInspector)oi);
-    case STRUCT:
-      return deparseStruct(obj, (StructObjectInspector)oi, false);
-    case UNION:
-      // Unsupported by JSON
-    default:
-      return null;
+    /**
+     * Parse a JSON list and its elements. This uses the Hive metadata for the
+     * list elements to determine how to parse the elements.
+     * 
+     * @param field - The JSON list to parse
+     * @param fieldTypeInfo - Metadata about the Hive column
+     * @return - A list of the parsed elements
+     */
+    private Object parseList(Object field, ListTypeInfo fieldTypeInfo) {
+        @SuppressWarnings("unchecked")
+        ArrayList<Object> list = (ArrayList<Object>) field;
+        TypeInfo elemTypeInfo = fieldTypeInfo.getListElementTypeInfo();
+
+        for (int i = 0; i < list.size(); i++) {
+            list.set(i, parseField(list.get(i), elemTypeInfo));
+        }
+
+        return list.toArray();
     }
-  }
-  
-  /**
-   * Deparses a row of data. We have to treat this one differently from
-   * other structs, because the field names for the root object do not match
-   * the column names for the Hive table.
-   * 
-   * @param obj - Object representing the top-level row
-   * @param structOI - ObjectInspector for the row
-   * @return - A deparsed row of data
-   */
-  private Object deparseRow(Object obj, ObjectInspector structOI) {
-    return deparseStruct(obj, (StructObjectInspector)structOI, true);
-  }
 
-  /**
-   * Deparses struct data into a serializable JSON object.
-   * 
-   * @param obj - Hive struct data
-   * @param structOI - ObjectInspector for the struct
-   * @param isRow - Whether or not this struct represents a top-level row
-   * @return - A deparsed struct
-   */
-  private Object deparseStruct(Object obj,
-                               StructObjectInspector structOI,
-                               boolean isRow) {
-    Map<Object,Object> struct = new HashMap<Object,Object>();
-    List<? extends StructField> fields = structOI.getAllStructFieldRefs();
-    for (int i = 0; i < fields.size(); i++) {
-      StructField field = fields.get(i);
-      // The top-level row object is treated slightly differently from other
-      // structs, because the field names for the row do not correctly reflect
-      // the Hive column names. For lower-level structs, we can get the field
-      // name from the associated StructField object.
-      String fieldName = isRow ? colNames.get(i) : field.getFieldName();
-      ObjectInspector fieldOI = field.getFieldObjectInspector();
-      Object fieldObj = structOI.getStructFieldData(obj, field);
-      struct.put(fieldName, deparseObject(fieldObj, fieldOI));
+    /**
+     * Parse a JSON object as a map. This uses the Hive metadata for the map
+     * values to determine how to parse the values. The map is assumed to have
+     * a string for a key.
+     * 
+     * @param field - The JSON list to parse
+     * @param fieldTypeInfo - Metadata about the Hive column
+     * @return
+     */
+    private Object parseMap(Object field, MapTypeInfo fieldTypeInfo) {
+        @SuppressWarnings("unchecked")
+        Map<Object, Object> map = (Map<Object, Object>) field;
+        TypeInfo valueTypeInfo = fieldTypeInfo.getMapValueTypeInfo();
+
+        for (Map.Entry<Object, Object> entry : map.entrySet()) {
+            map.put(entry.getKey(), parseField(entry.getValue(), valueTypeInfo));
+        }
+        return map;
     }
-    return struct;
-  }
 
-  /**
-   * Deparses a primitive type.
-   * 
-   * @param obj - Hive object to deparse
-   * @param oi - ObjectInspector for the object
-   * @return - A deparsed object
-   */
-  private Object deparsePrimitive(Object obj, PrimitiveObjectInspector primOI) {
-    return primOI.getPrimitiveJavaObject(obj);
-  }
-
-  private Object deparseMap(Object obj, MapObjectInspector mapOI) {
-    Map<Object,Object> map = new HashMap<Object,Object>();
-    ObjectInspector mapValOI = mapOI.getMapValueObjectInspector();
-    Map<?,?> fields = mapOI.getMap(obj);
-    for (Map.Entry<?,?> field : fields.entrySet()) {
-      Object fieldName = field.getKey();
-      Object fieldObj = field.getValue();
-      map.put(fieldName, deparseObject(fieldObj, mapValOI));
+    /**
+     * Return an ObjectInspector for the row of data
+     */
+    @Override
+    public ObjectInspector getObjectInspector() throws SerDeException {
+        return rowOI;
     }
-    return map;
-  }
 
-  /**
-   * Deparses a list and its elements.
-   * 
-   * @param obj - Hive object to deparse
-   * @param oi - ObjectInspector for the object
-   * @return - A deparsed object
-   */
-  private Object deparseList(Object obj, ListObjectInspector listOI) {
-    List<Object> list = new ArrayList<Object>();
-    List<?> field = listOI.getList(obj);
-    ObjectInspector elemOI = listOI.getListElementObjectInspector();
-    for (Object elem : field) {
-      list.add(deparseObject(elem, elemOI));
+    /**
+     * Unimplemented
+     */
+    @Override
+    public SerDeStats getSerDeStats() {
+        return null;
     }
-    return list;
-  }
+
+    /**
+     * JSON is just a textual representation, so our serialized class
+     * is just Text.
+     */
+    @Override
+    public Class<? extends Writable> getSerializedClass() {
+        return Text.class;
+    }
+
+    /**
+     * This method takes an object representing a row of data from Hive, and uses
+     * the ObjectInspector to get the data for each column and serialize it. This
+     * implementation deparses the row into an object that Jackson can easily
+     * serialize into a JSON blob.
+     */
+    @Override
+    public Writable serialize(Object obj, ObjectInspector oi)
+            throws SerDeException {
+        Object deparsedObj = deparseRow(obj, oi);
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            // Let Jackson do the work of serializing the object
+            return new Text(mapper.writeValueAsString(deparsedObj));
+        } catch (Exception e) {
+            throw new SerDeException(e);
+        }
+    }
+
+    /**
+     * Deparse a Hive object into a Jackson-serializable object. This uses
+     * the ObjectInspector to extract the column data.
+     * 
+     * @param obj - Hive object to deparse
+     * @param oi - ObjectInspector for the object
+     * @return - A deparsed object
+     */
+    private Object deparseObject(Object obj, ObjectInspector oi) {
+        switch (oi.getCategory()) {
+            case LIST:
+                return deparseList(obj, (ListObjectInspector) oi);
+            case MAP:
+                return deparseMap(obj, (MapObjectInspector) oi);
+            case PRIMITIVE:
+                return deparsePrimitive(obj, (PrimitiveObjectInspector) oi);
+            case STRUCT:
+                return deparseStruct(obj, (StructObjectInspector) oi, false);
+            case UNION:
+                // Unsupported by JSON
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * Deparses a row of data. We have to treat this one differently from
+     * other structs, because the field names for the root object do not match
+     * the column names for the Hive table.
+     * 
+     * @param obj - Object representing the top-level row
+     * @param structOI - ObjectInspector for the row
+     * @return - A deparsed row of data
+     */
+    private Object deparseRow(Object obj, ObjectInspector structOI) {
+        return deparseStruct(obj, (StructObjectInspector) structOI, true);
+    }
+
+    /**
+     * Deparses struct data into a serializable JSON object.
+     * 
+     * @param obj - Hive struct data
+     * @param structOI - ObjectInspector for the struct
+     * @param isRow - Whether or not this struct represents a top-level row
+     * @return - A deparsed struct
+     */
+    private Object deparseStruct(Object obj,
+            StructObjectInspector structOI,
+            boolean isRow) {
+        Map<Object, Object> struct = new HashMap<Object, Object>();
+        List<? extends StructField> fields = structOI.getAllStructFieldRefs();
+        for (int i = 0; i < fields.size(); i++) {
+            StructField field = fields.get(i);
+            // The top-level row object is treated slightly differently from other
+            // structs, because the field names for the row do not correctly reflect
+            // the Hive column names. For lower-level structs, we can get the field
+            // name from the associated StructField object.
+            String fieldName = isRow ? colNames.get(i) : field.getFieldName();
+            ObjectInspector fieldOI = field.getFieldObjectInspector();
+            Object fieldObj = structOI.getStructFieldData(obj, field);
+            struct.put(fieldName, deparseObject(fieldObj, fieldOI));
+        }
+        return struct;
+    }
+
+    /**
+     * Deparses a primitive type.
+     * 
+     * @param obj - Hive object to deparse
+     * @param oi - ObjectInspector for the object
+     * @return - A deparsed object
+     */
+    private Object deparsePrimitive(Object obj, PrimitiveObjectInspector primOI) {
+        return primOI.getPrimitiveJavaObject(obj);
+    }
+
+    private Object deparseMap(Object obj, MapObjectInspector mapOI) {
+        Map<Object, Object> map = new HashMap<Object, Object>();
+        ObjectInspector mapValOI = mapOI.getMapValueObjectInspector();
+        Map<?, ?> fields = mapOI.getMap(obj);
+        for (Map.Entry<?, ?> field : fields.entrySet()) {
+            Object fieldName = field.getKey();
+            Object fieldObj = field.getValue();
+            map.put(fieldName, deparseObject(fieldObj, mapValOI));
+        }
+        return map;
+    }
+
+    /**
+     * Deparses a list and its elements.
+     * 
+     * @param obj - Hive object to deparse
+     * @param oi - ObjectInspector for the object
+     * @return - A deparsed object
+     */
+    private Object deparseList(Object obj, ListObjectInspector listOI) {
+        List<Object> list = new ArrayList<Object>();
+        List<?> field = listOI.getList(obj);
+        ObjectInspector elemOI = listOI.getListElementObjectInspector();
+        for (Object elem : field) {
+            list.add(deparseObject(elem, elemOI));
+        }
+        return list;
+    }
 }

--- a/hive-serdes/src/main/java/com/cloudera/hive/serde/JSONSerDe.java
+++ b/hive-serdes/src/main/java/com/cloudera/hive/serde/JSONSerDe.java
@@ -148,8 +148,23 @@ public class JSONSerDe implements SerDe {
         return row;
     }
 
+    /*
+     * replace dot/minus and do lowerCase at once 
+     */
     static final String patchKey(String key) {
-        return key.toLowerCase().replaceAll("[\\.-]", "_");
+        StringBuilder buffer = new StringBuilder(key.length());
+        for (char character : key.toCharArray()) {
+            switch (character) {
+                case '.':
+                case '-':
+                    buffer.append('_');
+                    break;
+                default:
+                    buffer.append(Character.toLowerCase(character));
+                    break;
+            }
+        }
+        return buffer.toString();
     }
 
     /**

--- a/hive-serdes/src/main/java/com/cloudera/hive/serde/JSONSerDe.java
+++ b/hive-serdes/src/main/java/com/cloudera/hive/serde/JSONSerDe.java
@@ -1,20 +1,20 @@
 /**
-* Licensed to the Apache Software Foundation (ASF) under one
-* or more contributor license agreements. See the NOTICE file
-* distributed with this work for additional information
-* regarding copyright ownership. The ASF licenses this file
-* to you under the Apache License, Version 2.0 (the
-* "License"); you may not use this file except in compliance
-* with the License. You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.cloudera.hive.serde;
 
 import java.util.ArrayList;
@@ -46,32 +46,32 @@ import org.apache.hadoop.io.Writable;
 import org.codehaus.jackson.map.ObjectMapper;
 
 /**
-* This SerDe can be used for processing JSON data in Hive. It supports
-* arbitrary JSON data, and can handle all Hive types except for UNION.
-* However, the JSON data is expected to be a series of discrete records,
-* rather than a JSON array of objects.
-*
-* The Hive table is expected to contain columns with names corresponding to
-* fields in the JSON data, but it is not necessary for every JSON field to
-* have a corresponding Hive column. Those JSON fields will be ignored during
-* queries.
-*
-* Example:
-*
-* { "a": 1, "b": [ "str1", "str2" ], "c": { "field1": "val1" } }
-*
-* Could correspond to a table:
-*
-* CREATE TABLE foo (a INT, b ARRAY<STRING>, c STRUCT<field1:STRING>);
-*
-* JSON objects can also interpreted as a Hive MAP type, so long as the keys
-* and values in the JSON object are all of the appropriate types. For example,
-* in the JSON above, another valid table declaraction would be:
-*
-* CREATE TABLE foo (a INT, b ARRAY<STRING>, c MAP<STRING,STRING>);
-*
-* Only STRING keys are supported for Hive MAPs.
-*/
+ * This SerDe can be used for processing JSON data in Hive. It supports
+ * arbitrary JSON data, and can handle all Hive types except for UNION.
+ * However, the JSON data is expected to be a series of discrete records,
+ * rather than a JSON array of objects.
+ * 
+ * The Hive table is expected to contain columns with names corresponding to
+ * fields in the JSON data, but it is not necessary for every JSON field to
+ * have a corresponding Hive column. Those JSON fields will be ignored during
+ * queries.
+ * 
+ * Example:
+ * 
+ * { "a": 1, "b": [ "str1", "str2" ], "c": { "field1": "val1" } }
+ * 
+ * Could correspond to a table:
+ * 
+ * CREATE TABLE foo (a INT, b ARRAY<STRING>, c STRUCT<field1:STRING>);
+ * 
+ * JSON objects can also interpreted as a Hive MAP type, so long as the keys
+ * and values in the JSON object are all of the appropriate types. For example,
+ * in the JSON above, another valid table declaraction would be:
+ * 
+ * CREATE TABLE foo (a INT, b ARRAY<STRING>, c MAP<STRING,STRING>);
+ * 
+ * Only STRING keys are supported for Hive MAPs.
+ */
 public class JSONSerDe implements SerDe {
   
   private StructTypeInfo rowTypeInfo;
@@ -80,11 +80,11 @@ public class JSONSerDe implements SerDe {
   private List<Object> row = new ArrayList<Object>();
   
   /**
-* An initialization function used to gather information about the table.
-* Typically, a SerDe implementation will be interested in the list of
-* column names and their types. That information will be used to help perform
-* actual serialization and deserialization of data.
-*/
+   * An initialization function used to gather information about the table.
+   * Typically, a SerDe implementation will be interested in the list of
+   * column names and their types. That information will be used to help perform
+   * actual serialization and deserialization of data.
+   */
   @Override
   public void initialize(Configuration conf, Properties tbl)
       throws SerDeException {
@@ -105,17 +105,17 @@ public class JSONSerDe implements SerDe {
   }
 
   /**
-* This method does the work of deserializing a record into Java objects that
-* Hive can work with via the ObjectInspector interface. For this SerDe, the
-* blob that is passed in is a JSON string, and the Jackson JSON parser is
-* being used to translate the string into Java objects.
-*
-* The JSON deserialization works by taking the column names in the Hive
-* table, and looking up those fields in the parsed JSON object. If the value
-* of the field is not a primitive, the object is parsed further.
-*/
-@SuppressWarnings("rawtypes")
-@Override
+   * This method does the work of deserializing a record into Java objects that
+   * Hive can work with via the ObjectInspector interface. For this SerDe, the
+   * blob that is passed in is a JSON string, and the Jackson JSON parser is
+   * being used to translate the string into Java objects.
+   * 
+   * The JSON deserialization works by taking the column names in the Hive
+   * table, and looking up those fields in the parsed JSON object. If the value
+   * of the field is not a primitive, the object is parsed further.
+   */
+  @SuppressWarnings("rawtypes")
+  @Override
   public Object deserialize(Writable blob) throws SerDeException {
     Map<?,?> root = null;
     row.clear();
@@ -169,12 +169,12 @@ public class JSONSerDe implements SerDe {
   }
   
   /**
-* Parses a JSON object according to the Hive column's type.
-*
-* @param field - The JSON object to parse
-* @param fieldTypeInfo - Metadata about the Hive column
-* @return - The parsed value of the field
-*/
+   * Parses a JSON object according to the Hive column's type.
+   * 
+   * @param field - The JSON object to parse
+   * @param fieldTypeInfo - Metadata about the Hive column
+   * @return - The parsed value of the field
+   */
   private Object parseField(Object field, TypeInfo fieldTypeInfo) {
     switch (fieldTypeInfo.getCategory()) {
     case PRIMITIVE:
@@ -198,13 +198,13 @@ public class JSONSerDe implements SerDe {
   }
   
   /**
-* Parses a JSON object and its fields. The Hive metadata is used to
-* determine how to parse the object fields.
-*
-* @param field - The JSON object to parse
-* @param fieldTypeInfo - Metadata about the Hive column
-* @return - A map representing the object and its fields
-*/
+   * Parses a JSON object and its fields. The Hive metadata is used to
+   * determine how to parse the object fields.
+   * 
+   * @param field - The JSON object to parse
+   * @param fieldTypeInfo - Metadata about the Hive column
+   * @return - A map representing the object and its fields
+   */
   private Object parseStruct(Object field, StructTypeInfo fieldTypeInfo) {
     @SuppressWarnings("unchecked")
     Map<Object,Object> map = (Map<Object,Object>)field;
@@ -219,13 +219,13 @@ public class JSONSerDe implements SerDe {
   }
 
   /**
-* Parse a JSON list and its elements. This uses the Hive metadata for the
-* list elements to determine how to parse the elements.
-*
-* @param field - The JSON list to parse
-* @param fieldTypeInfo - Metadata about the Hive column
-* @return - A list of the parsed elements
-*/
+   * Parse a JSON list and its elements. This uses the Hive metadata for the
+   * list elements to determine how to parse the elements.
+   * 
+   * @param field - The JSON list to parse
+   * @param fieldTypeInfo - Metadata about the Hive column
+   * @return - A list of the parsed elements
+   */
   private Object parseList(Object field, ListTypeInfo fieldTypeInfo) {
     @SuppressWarnings("unchecked")
     ArrayList<Object> list = (ArrayList<Object>) field;
@@ -239,14 +239,14 @@ public class JSONSerDe implements SerDe {
   }
 
   /**
-* Parse a JSON object as a map. This uses the Hive metadata for the map
-* values to determine how to parse the values. The map is assumed to have
-* a string for a key.
-*
-* @param field - The JSON list to parse
-* @param fieldTypeInfo - Metadata about the Hive column
-* @return
-*/
+   * Parse a JSON object as a map. This uses the Hive metadata for the map
+   * values to determine how to parse the values. The map is assumed to have
+   * a string for a key.
+   * 
+   * @param field - The JSON list to parse
+   * @param fieldTypeInfo - Metadata about the Hive column
+   * @return
+   */
   private Object parseMap(Object field, MapTypeInfo fieldTypeInfo) {
     @SuppressWarnings("unchecked")
     Map<Object,Object> map = (Map<Object,Object>) field;
@@ -259,36 +259,36 @@ public class JSONSerDe implements SerDe {
   }
 
   /**
-* Return an ObjectInspector for the row of data
-*/
+   * Return an ObjectInspector for the row of data
+   */
   @Override
   public ObjectInspector getObjectInspector() throws SerDeException {
     return rowOI;
   }
 
   /**
-* Unimplemented
-*/
+   * Unimplemented
+   */
   @Override
   public SerDeStats getSerDeStats() {
     return null;
   }
 
   /**
-* JSON is just a textual representation, so our serialized class
-* is just Text.
-*/
+   * JSON is just a textual representation, so our serialized class
+   * is just Text.
+   */
   @Override
   public Class<? extends Writable> getSerializedClass() {
     return Text.class;
   }
 
   /**
-* This method takes an object representing a row of data from Hive, and uses
-* the ObjectInspector to get the data for each column and serialize it. This
-* implementation deparses the row into an object that Jackson can easily
-* serialize into a JSON blob.
-*/
+   * This method takes an object representing a row of data from Hive, and uses
+   * the ObjectInspector to get the data for each column and serialize it. This
+   * implementation deparses the row into an object that Jackson can easily
+   * serialize into a JSON blob.
+   */
   @Override
   public Writable serialize(Object obj, ObjectInspector oi)
       throws SerDeException {
@@ -303,13 +303,13 @@ public class JSONSerDe implements SerDe {
   }
 
   /**
-* Deparse a Hive object into a Jackson-serializable object. This uses
-* the ObjectInspector to extract the column data.
-*
-* @param obj - Hive object to deparse
-* @param oi - ObjectInspector for the object
-* @return - A deparsed object
-*/
+   * Deparse a Hive object into a Jackson-serializable object. This uses
+   * the ObjectInspector to extract the column data.
+   * 
+   * @param obj - Hive object to deparse
+   * @param oi - ObjectInspector for the object
+   * @return - A deparsed object
+   */
   private Object deparseObject(Object obj, ObjectInspector oi) {
     switch (oi.getCategory()) {
     case LIST:
@@ -328,26 +328,26 @@ public class JSONSerDe implements SerDe {
   }
   
   /**
-* Deparses a row of data. We have to treat this one differently from
-* other structs, because the field names for the root object do not match
-* the column names for the Hive table.
-*
-* @param obj - Object representing the top-level row
-* @param structOI - ObjectInspector for the row
-* @return - A deparsed row of data
-*/
+   * Deparses a row of data. We have to treat this one differently from
+   * other structs, because the field names for the root object do not match
+   * the column names for the Hive table.
+   * 
+   * @param obj - Object representing the top-level row
+   * @param structOI - ObjectInspector for the row
+   * @return - A deparsed row of data
+   */
   private Object deparseRow(Object obj, ObjectInspector structOI) {
     return deparseStruct(obj, (StructObjectInspector)structOI, true);
   }
 
   /**
-* Deparses struct data into a serializable JSON object.
-*
-* @param obj - Hive struct data
-* @param structOI - ObjectInspector for the struct
-* @param isRow - Whether or not this struct represents a top-level row
-* @return - A deparsed struct
-*/
+   * Deparses struct data into a serializable JSON object.
+   * 
+   * @param obj - Hive struct data
+   * @param structOI - ObjectInspector for the struct
+   * @param isRow - Whether or not this struct represents a top-level row
+   * @return - A deparsed struct
+   */
   private Object deparseStruct(Object obj,
                                StructObjectInspector structOI,
                                boolean isRow) {
@@ -368,12 +368,12 @@ public class JSONSerDe implements SerDe {
   }
 
   /**
-* Deparses a primitive type.
-*
-* @param obj - Hive object to deparse
-* @param oi - ObjectInspector for the object
-* @return - A deparsed object
-*/
+   * Deparses a primitive type.
+   * 
+   * @param obj - Hive object to deparse
+   * @param oi - ObjectInspector for the object
+   * @return - A deparsed object
+   */
   private Object deparsePrimitive(Object obj, PrimitiveObjectInspector primOI) {
     return primOI.getPrimitiveJavaObject(obj);
   }
@@ -391,12 +391,12 @@ public class JSONSerDe implements SerDe {
   }
 
   /**
-* Deparses a list and its elements.
-*
-* @param obj - Hive object to deparse
-* @param oi - ObjectInspector for the object
-* @return - A deparsed object
-*/
+   * Deparses a list and its elements.
+   * 
+   * @param obj - Hive object to deparse
+   * @param oi - ObjectInspector for the object
+   * @return - A deparsed object
+   */
   private Object deparseList(Object obj, ListObjectInspector listOI) {
     List<Object> list = new ArrayList<Object>();
     List<?> field = listOI.getList(obj);

--- a/hive-serdes/src/main/java/com/cloudera/hive/serde/JSONSerDe.java
+++ b/hive-serdes/src/main/java/com/cloudera/hive/serde/JSONSerDe.java
@@ -131,7 +131,7 @@ public class JSONSerDe implements SerDe {
         // Lowercase the keys as expected by hive
         Map<String, Object> lowerRoot = new HashMap<String, Object>();
         for (Map.Entry<?, ?> entry : root.entrySet()) {
-            lowerRoot.put(((String) entry.getKey()).toLowerCase(), entry.getValue());
+            lowerRoot.put(patchKey((String) entry.getKey()), entry.getValue());
         }
         root = lowerRoot;
 
@@ -146,6 +146,10 @@ public class JSONSerDe implements SerDe {
             row.add(value);
         }
         return row;
+    }
+
+    private String patchKey(String key) {
+        return key.toLowerCase().replaceAll("[\\.-]", "_");
     }
 
     /**

--- a/hive-serdes/src/main/java/com/cloudera/hive/serde/JSONSerDe.java
+++ b/hive-serdes/src/main/java/com/cloudera/hive/serde/JSONSerDe.java
@@ -148,7 +148,7 @@ public class JSONSerDe implements SerDe {
         return row;
     }
 
-    private String patchKey(String key) {
+    static final String patchKey(String key) {
         return key.toLowerCase().replaceAll("[\\.-]", "_");
     }
 

--- a/hive-serdes/src/main/java/com/cloudera/hive/serde/JSONSerDe.java
+++ b/hive-serdes/src/main/java/com/cloudera/hive/serde/JSONSerDe.java
@@ -1,20 +1,20 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 package com.cloudera.hive.serde;
 
 import java.util.ArrayList;
@@ -46,363 +46,364 @@ import org.apache.hadoop.io.Writable;
 import org.codehaus.jackson.map.ObjectMapper;
 
 /**
- * This SerDe can be used for processing JSON data in Hive. It supports
- * arbitrary JSON data, and can handle all Hive types except for UNION.
- * However, the JSON data is expected to be a series of discrete records,
- * rather than a JSON array of objects.
- * 
- * The Hive table is expected to contain columns with names corresponding to
- * fields in the JSON data, but it is not necessary for every JSON field to
- * have a corresponding Hive column. Those JSON fields will be ignored during
- * queries.
- * 
- * Example:
- * 
- * { "a": 1, "b": [ "str1", "str2" ], "c": { "field1": "val1" } }
- * 
- * Could correspond to a table:
- * 
- * CREATE TABLE foo (a INT, b ARRAY<STRING>, c STRUCT<field1:STRING>);
- * 
- * JSON objects can also interpreted as a Hive MAP type, so long as the keys
- * and values in the JSON object are all of the appropriate types. For example,
- * in the JSON above, another valid table declaraction would be:
- * 
- * CREATE TABLE foo (a INT, b ARRAY<STRING>, c MAP<STRING,STRING>);
- * 
- * Only STRING keys are supported for Hive MAPs.
- */
+* This SerDe can be used for processing JSON data in Hive. It supports
+* arbitrary JSON data, and can handle all Hive types except for UNION.
+* However, the JSON data is expected to be a series of discrete records,
+* rather than a JSON array of objects.
+*
+* The Hive table is expected to contain columns with names corresponding to
+* fields in the JSON data, but it is not necessary for every JSON field to
+* have a corresponding Hive column. Those JSON fields will be ignored during
+* queries.
+*
+* Example:
+*
+* { "a": 1, "b": [ "str1", "str2" ], "c": { "field1": "val1" } }
+*
+* Could correspond to a table:
+*
+* CREATE TABLE foo (a INT, b ARRAY<STRING>, c STRUCT<field1:STRING>);
+*
+* JSON objects can also interpreted as a Hive MAP type, so long as the keys
+* and values in the JSON object are all of the appropriate types. For example,
+* in the JSON above, another valid table declaraction would be:
+*
+* CREATE TABLE foo (a INT, b ARRAY<STRING>, c MAP<STRING,STRING>);
+*
+* Only STRING keys are supported for Hive MAPs.
+*/
 public class JSONSerDe implements SerDe {
+  
+  private StructTypeInfo rowTypeInfo;
+  private ObjectInspector rowOI;
+  private List<String> colNames;
+  private List<Object> row = new ArrayList<Object>();
+  
+  /**
+* An initialization function used to gather information about the table.
+* Typically, a SerDe implementation will be interested in the list of
+* column names and their types. That information will be used to help perform
+* actual serialization and deserialization of data.
+*/
+  @Override
+  public void initialize(Configuration conf, Properties tbl)
+      throws SerDeException {
+    // Get a list of the table's column names.
+    String colNamesStr = tbl.getProperty(serdeConstants.LIST_COLUMNS);
+    colNames = Arrays.asList(colNamesStr.split(","));
+    
+    // Get a list of TypeInfos for the columns. This list lines up with
+    // the list of column names.
+    String colTypesStr = tbl.getProperty(serdeConstants.LIST_COLUMN_TYPES);
+    List<TypeInfo> colTypes =
+        TypeInfoUtils.getTypeInfosFromTypeString(colTypesStr);
+    
+    rowTypeInfo =
+        (StructTypeInfo) TypeInfoFactory.getStructTypeInfo(colNames, colTypes);
+    rowOI =
+        TypeInfoUtils.getStandardJavaObjectInspectorFromTypeInfo(rowTypeInfo);
+  }
 
-    private StructTypeInfo rowTypeInfo;
-    private ObjectInspector rowOI;
-    private List<String> colNames;
-    private List<Object> row = new ArrayList<Object>();
-
-    /**
-     * An initialization function used to gather information about the table.
-     * Typically, a SerDe implementation will be interested in the list of
-     * column names and their types. That information will be used to help perform
-     * actual serialization and deserialization of data.
-     */
-    @Override
-    public void initialize(Configuration conf, Properties tbl)
-            throws SerDeException {
-        // Get a list of the table's column names.
-        String colNamesStr = tbl.getProperty(serdeConstants.LIST_COLUMNS);
-        colNames = Arrays.asList(colNamesStr.split(","));
-
-        // Get a list of TypeInfos for the columns. This list lines up with
-        // the list of column names.
-        String colTypesStr = tbl.getProperty(serdeConstants.LIST_COLUMN_TYPES);
-        List<TypeInfo> colTypes =
-                TypeInfoUtils.getTypeInfosFromTypeString(colTypesStr);
-
-        rowTypeInfo =
-                (StructTypeInfo) TypeInfoFactory.getStructTypeInfo(colNames, colTypes);
-        rowOI =
-                TypeInfoUtils.getStandardJavaObjectInspectorFromTypeInfo(rowTypeInfo);
+  /**
+* This method does the work of deserializing a record into Java objects that
+* Hive can work with via the ObjectInspector interface. For this SerDe, the
+* blob that is passed in is a JSON string, and the Jackson JSON parser is
+* being used to translate the string into Java objects.
+*
+* The JSON deserialization works by taking the column names in the Hive
+* table, and looking up those fields in the parsed JSON object. If the value
+* of the field is not a primitive, the object is parsed further.
+*/
+@SuppressWarnings("rawtypes")
+@Override
+  public Object deserialize(Writable blob) throws SerDeException {
+    Map<?,?> root = null;
+    row.clear();
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      // This is really a Map<String, Object>. For more information about how
+      // Jackson parses JSON in this example, see
+      // http://wiki.fasterxml.com/JacksonDataBinding
+      root = mapper.readValue(blob.toString(), Map.class);
+    } catch (Exception e) {
+      throw new SerDeException(e);
     }
 
-    /**
-     * This method does the work of deserializing a record into Java objects that
-     * Hive can work with via the ObjectInspector interface. For this SerDe, the
-     * blob that is passed in is a JSON string, and the Jackson JSON parser is
-     * being used to translate the string into Java objects.
-     * 
-     * The JSON deserialization works by taking the column names in the Hive
-     * table, and looking up those fields in the parsed JSON object. If the value
-     * of the field is not a primitive, the object is parsed further.
-     */
-    @Override
-    public Object deserialize(Writable blob) throws SerDeException {
-        Map<?, ?> root = null;
-        row.clear();
-        try {
-            ObjectMapper mapper = new ObjectMapper();
-            // This is really a Map<String, Object>. For more information about how
-            // Jackson parses JSON in this example, see
-            // http://wiki.fasterxml.com/JacksonDataBinding
-            root = mapper.readValue(blob.toString(), Map.class);
-        } catch (Exception e) {
-            throw new SerDeException(e);
-        }
-
-        // Lowercase the keys as expected by hive
-        Map<String, Object> lowerRoot = new HashMap<String, Object>();
-        for (Map.Entry<?, ?> entry : root.entrySet()) {
-            lowerRoot.put(patchKey((String) entry.getKey()), entry.getValue());
-        }
-        root = lowerRoot;
-
-        Object value = null;
-        for (String fieldName : rowTypeInfo.getAllStructFieldNames()) {
-            try {
-                TypeInfo fieldTypeInfo = rowTypeInfo.getStructFieldTypeInfo(fieldName);
-                value = parseField(root.get(fieldName), fieldTypeInfo);
-            } catch (Exception e) {
-                value = null;
-            }
-            row.add(value);
-        }
-        return row;
+    // Lowercase the keys as expected by hive
+    Map<String, Object> lowerRoot = new HashMap<String, Object>();
+    for(Map.Entry entry: root.entrySet()) {
+      lowerRoot.put(patchKey((String) entry.getKey()), entry.getValue());
     }
-
-    /*
-     * replace dot/minus and do lowerCase at once 
-     */
-    static final String patchKey(String key) {
-        StringBuilder buffer = new StringBuilder(key.length());
-        for (char character : key.toCharArray()) {
-            switch (character) {
-                case '.':
-                case '-':
-                    buffer.append('_');
-                    break;
-                default:
-                    buffer.append(Character.toLowerCase(character));
-                    break;
-            }
-        }
-        return buffer.toString();
+    root = lowerRoot;
+    
+    Object value= null;
+    for (String fieldName : rowTypeInfo.getAllStructFieldNames()) {
+      try {
+        TypeInfo fieldTypeInfo = rowTypeInfo.getStructFieldTypeInfo(fieldName);
+        value = parseField(root.get(fieldName), fieldTypeInfo);
+      } catch (Exception e) {
+        value = null;
+      }
+      row.add(value);
     }
-
-    /**
-     * Parses a JSON object according to the Hive column's type.
-     * 
-     * @param field - The JSON object to parse
-     * @param fieldTypeInfo - Metadata about the Hive column
-     * @return - The parsed value of the field
-     */
-    private Object parseField(Object field, TypeInfo fieldTypeInfo) {
-        switch (fieldTypeInfo.getCategory()) {
-            case PRIMITIVE:
-                // Jackson will return the right thing in this case, so just return
-                // the object
-                if (field instanceof String) {
-                    field = field.toString().replaceAll("\n", "\\\\n");
-                }
-                return field;
-            case LIST:
-                return parseList(field, (ListTypeInfo) fieldTypeInfo);
-            case MAP:
-                return parseMap(field, (MapTypeInfo) fieldTypeInfo);
-            case STRUCT:
-                return parseStruct(field, (StructTypeInfo) fieldTypeInfo);
-            case UNION:
-                // Unsupported by JSON
-            default:
-                return null;
-        }
+    return row;
+  }
+  
+  /*
+   * replace dot/minus and do lowerCase at once
+   */
+  static final String patchKey(String key) {
+    StringBuilder buffer = new StringBuilder(key.length());
+    for (char character : key.toCharArray()) {
+      switch (character) {
+        case '.':
+        case '-':
+          buffer.append('_');
+          break;
+        default:
+          buffer.append(Character.toLowerCase(character));
+          break;
+      }
     }
-
-    /**
-     * Parses a JSON object and its fields. The Hive metadata is used to
-     * determine how to parse the object fields.
-     * 
-     * @param field - The JSON object to parse
-     * @param fieldTypeInfo - Metadata about the Hive column
-     * @return - A map representing the object and its fields
-     */
-    private Object parseStruct(Object field, StructTypeInfo fieldTypeInfo) {
-        @SuppressWarnings("unchecked")
-        Map<Object, Object> map = (Map<Object, Object>) field;
-        ArrayList<TypeInfo> structTypes = fieldTypeInfo.getAllStructFieldTypeInfos();
-        ArrayList<String> structNames = fieldTypeInfo.getAllStructFieldNames();
-
-        List<Object> structRow = new ArrayList<Object>(structTypes.size());
-        for (int i = 0; i < structNames.size(); i++) {
-            structRow.add(parseField(map.get(structNames.get(i)), structTypes.get(i)));
-        }
-        return structRow;
+    return buffer.toString();
+  }
+  
+  /**
+* Parses a JSON object according to the Hive column's type.
+*
+* @param field - The JSON object to parse
+* @param fieldTypeInfo - Metadata about the Hive column
+* @return - The parsed value of the field
+*/
+  private Object parseField(Object field, TypeInfo fieldTypeInfo) {
+    switch (fieldTypeInfo.getCategory()) {
+    case PRIMITIVE:
+      // Jackson will return the right thing in this case, so just return
+      // the object
+      if (field instanceof String) {
+        field = field.toString().replaceAll("\n", "\\\\n");
+      }
+      return field;
+    case LIST:
+      return parseList(field, (ListTypeInfo) fieldTypeInfo);
+    case MAP:
+      return parseMap(field, (MapTypeInfo) fieldTypeInfo);
+    case STRUCT:
+      return parseStruct(field, (StructTypeInfo) fieldTypeInfo);
+    case UNION:
+      // Unsupported by JSON
+    default:
+      return null;
     }
-
-    /**
-     * Parse a JSON list and its elements. This uses the Hive metadata for the
-     * list elements to determine how to parse the elements.
-     * 
-     * @param field - The JSON list to parse
-     * @param fieldTypeInfo - Metadata about the Hive column
-     * @return - A list of the parsed elements
-     */
-    private Object parseList(Object field, ListTypeInfo fieldTypeInfo) {
-        @SuppressWarnings("unchecked")
-        ArrayList<Object> list = (ArrayList<Object>) field;
-        TypeInfo elemTypeInfo = fieldTypeInfo.getListElementTypeInfo();
-
-        for (int i = 0; i < list.size(); i++) {
-            list.set(i, parseField(list.get(i), elemTypeInfo));
-        }
-
-        return list.toArray();
+  }
+  
+  /**
+* Parses a JSON object and its fields. The Hive metadata is used to
+* determine how to parse the object fields.
+*
+* @param field - The JSON object to parse
+* @param fieldTypeInfo - Metadata about the Hive column
+* @return - A map representing the object and its fields
+*/
+  private Object parseStruct(Object field, StructTypeInfo fieldTypeInfo) {
+    @SuppressWarnings("unchecked")
+    Map<Object,Object> map = (Map<Object,Object>)field;
+    ArrayList<TypeInfo> structTypes = fieldTypeInfo.getAllStructFieldTypeInfos();
+    ArrayList<String> structNames = fieldTypeInfo.getAllStructFieldNames();
+    
+    List<Object> structRow = new ArrayList<Object>(structTypes.size());
+    for (int i = 0; i < structNames.size(); i++) {
+      structRow.add(parseField(map.get(structNames.get(i)), structTypes.get(i)));
     }
+    return structRow;
+  }
 
-    /**
-     * Parse a JSON object as a map. This uses the Hive metadata for the map
-     * values to determine how to parse the values. The map is assumed to have
-     * a string for a key.
-     * 
-     * @param field - The JSON list to parse
-     * @param fieldTypeInfo - Metadata about the Hive column
-     * @return
-     */
-    private Object parseMap(Object field, MapTypeInfo fieldTypeInfo) {
-        @SuppressWarnings("unchecked")
-        Map<Object, Object> map = (Map<Object, Object>) field;
-        TypeInfo valueTypeInfo = fieldTypeInfo.getMapValueTypeInfo();
-
-        for (Map.Entry<Object, Object> entry : map.entrySet()) {
-            map.put(entry.getKey(), parseField(entry.getValue(), valueTypeInfo));
-        }
-        return map;
+  /**
+* Parse a JSON list and its elements. This uses the Hive metadata for the
+* list elements to determine how to parse the elements.
+*
+* @param field - The JSON list to parse
+* @param fieldTypeInfo - Metadata about the Hive column
+* @return - A list of the parsed elements
+*/
+  private Object parseList(Object field, ListTypeInfo fieldTypeInfo) {
+    @SuppressWarnings("unchecked")
+    ArrayList<Object> list = (ArrayList<Object>) field;
+    TypeInfo elemTypeInfo = fieldTypeInfo.getListElementTypeInfo();
+    
+    for (int i = 0; i < list.size(); i++) {
+      list.set(i, parseField(list.get(i), elemTypeInfo));
     }
+    
+    return list.toArray();
+  }
 
-    /**
-     * Return an ObjectInspector for the row of data
-     */
-    @Override
-    public ObjectInspector getObjectInspector() throws SerDeException {
-        return rowOI;
+  /**
+* Parse a JSON object as a map. This uses the Hive metadata for the map
+* values to determine how to parse the values. The map is assumed to have
+* a string for a key.
+*
+* @param field - The JSON list to parse
+* @param fieldTypeInfo - Metadata about the Hive column
+* @return
+*/
+  private Object parseMap(Object field, MapTypeInfo fieldTypeInfo) {
+    @SuppressWarnings("unchecked")
+    Map<Object,Object> map = (Map<Object,Object>) field;
+    TypeInfo valueTypeInfo = fieldTypeInfo.getMapValueTypeInfo();
+    
+    for (Map.Entry<Object,Object> entry : map.entrySet()) {
+      map.put(entry.getKey(), parseField(entry.getValue(), valueTypeInfo));
     }
+    return map;
+  }
 
-    /**
-     * Unimplemented
-     */
-    @Override
-    public SerDeStats getSerDeStats() {
-        return null;
-    }
+  /**
+* Return an ObjectInspector for the row of data
+*/
+  @Override
+  public ObjectInspector getObjectInspector() throws SerDeException {
+    return rowOI;
+  }
 
-    /**
-     * JSON is just a textual representation, so our serialized class
-     * is just Text.
-     */
-    @Override
-    public Class<? extends Writable> getSerializedClass() {
-        return Text.class;
-    }
+  /**
+* Unimplemented
+*/
+  @Override
+  public SerDeStats getSerDeStats() {
+    return null;
+  }
 
-    /**
-     * This method takes an object representing a row of data from Hive, and uses
-     * the ObjectInspector to get the data for each column and serialize it. This
-     * implementation deparses the row into an object that Jackson can easily
-     * serialize into a JSON blob.
-     */
-    @Override
-    public Writable serialize(Object obj, ObjectInspector oi)
-            throws SerDeException {
-        Object deparsedObj = deparseRow(obj, oi);
-        ObjectMapper mapper = new ObjectMapper();
-        try {
-            // Let Jackson do the work of serializing the object
-            return new Text(mapper.writeValueAsString(deparsedObj));
-        } catch (Exception e) {
-            throw new SerDeException(e);
-        }
-    }
+  /**
+* JSON is just a textual representation, so our serialized class
+* is just Text.
+*/
+  @Override
+  public Class<? extends Writable> getSerializedClass() {
+    return Text.class;
+  }
 
-    /**
-     * Deparse a Hive object into a Jackson-serializable object. This uses
-     * the ObjectInspector to extract the column data.
-     * 
-     * @param obj - Hive object to deparse
-     * @param oi - ObjectInspector for the object
-     * @return - A deparsed object
-     */
-    private Object deparseObject(Object obj, ObjectInspector oi) {
-        switch (oi.getCategory()) {
-            case LIST:
-                return deparseList(obj, (ListObjectInspector) oi);
-            case MAP:
-                return deparseMap(obj, (MapObjectInspector) oi);
-            case PRIMITIVE:
-                return deparsePrimitive(obj, (PrimitiveObjectInspector) oi);
-            case STRUCT:
-                return deparseStruct(obj, (StructObjectInspector) oi, false);
-            case UNION:
-                // Unsupported by JSON
-            default:
-                return null;
-        }
+  /**
+* This method takes an object representing a row of data from Hive, and uses
+* the ObjectInspector to get the data for each column and serialize it. This
+* implementation deparses the row into an object that Jackson can easily
+* serialize into a JSON blob.
+*/
+  @Override
+  public Writable serialize(Object obj, ObjectInspector oi)
+      throws SerDeException {
+    Object deparsedObj = deparseRow(obj, oi);
+    ObjectMapper mapper = new ObjectMapper();
+    try {
+      // Let Jackson do the work of serializing the object
+      return new Text(mapper.writeValueAsString(deparsedObj));
+    } catch (Exception e) {
+      throw new SerDeException(e);
     }
+  }
 
-    /**
-     * Deparses a row of data. We have to treat this one differently from
-     * other structs, because the field names for the root object do not match
-     * the column names for the Hive table.
-     * 
-     * @param obj - Object representing the top-level row
-     * @param structOI - ObjectInspector for the row
-     * @return - A deparsed row of data
-     */
-    private Object deparseRow(Object obj, ObjectInspector structOI) {
-        return deparseStruct(obj, (StructObjectInspector) structOI, true);
+  /**
+* Deparse a Hive object into a Jackson-serializable object. This uses
+* the ObjectInspector to extract the column data.
+*
+* @param obj - Hive object to deparse
+* @param oi - ObjectInspector for the object
+* @return - A deparsed object
+*/
+  private Object deparseObject(Object obj, ObjectInspector oi) {
+    switch (oi.getCategory()) {
+    case LIST:
+      return deparseList(obj, (ListObjectInspector)oi);
+    case MAP:
+      return deparseMap(obj, (MapObjectInspector)oi);
+    case PRIMITIVE:
+      return deparsePrimitive(obj, (PrimitiveObjectInspector)oi);
+    case STRUCT:
+      return deparseStruct(obj, (StructObjectInspector)oi, false);
+    case UNION:
+      // Unsupported by JSON
+    default:
+      return null;
     }
+  }
+  
+  /**
+* Deparses a row of data. We have to treat this one differently from
+* other structs, because the field names for the root object do not match
+* the column names for the Hive table.
+*
+* @param obj - Object representing the top-level row
+* @param structOI - ObjectInspector for the row
+* @return - A deparsed row of data
+*/
+  private Object deparseRow(Object obj, ObjectInspector structOI) {
+    return deparseStruct(obj, (StructObjectInspector)structOI, true);
+  }
 
-    /**
-     * Deparses struct data into a serializable JSON object.
-     * 
-     * @param obj - Hive struct data
-     * @param structOI - ObjectInspector for the struct
-     * @param isRow - Whether or not this struct represents a top-level row
-     * @return - A deparsed struct
-     */
-    private Object deparseStruct(Object obj,
-            StructObjectInspector structOI,
-            boolean isRow) {
-        Map<Object, Object> struct = new HashMap<Object, Object>();
-        List<? extends StructField> fields = structOI.getAllStructFieldRefs();
-        for (int i = 0; i < fields.size(); i++) {
-            StructField field = fields.get(i);
-            // The top-level row object is treated slightly differently from other
-            // structs, because the field names for the row do not correctly reflect
-            // the Hive column names. For lower-level structs, we can get the field
-            // name from the associated StructField object.
-            String fieldName = isRow ? colNames.get(i) : field.getFieldName();
-            ObjectInspector fieldOI = field.getFieldObjectInspector();
-            Object fieldObj = structOI.getStructFieldData(obj, field);
-            struct.put(fieldName, deparseObject(fieldObj, fieldOI));
-        }
-        return struct;
+  /**
+* Deparses struct data into a serializable JSON object.
+*
+* @param obj - Hive struct data
+* @param structOI - ObjectInspector for the struct
+* @param isRow - Whether or not this struct represents a top-level row
+* @return - A deparsed struct
+*/
+  private Object deparseStruct(Object obj,
+                               StructObjectInspector structOI,
+                               boolean isRow) {
+    Map<Object,Object> struct = new HashMap<Object,Object>();
+    List<? extends StructField> fields = structOI.getAllStructFieldRefs();
+    for (int i = 0; i < fields.size(); i++) {
+      StructField field = fields.get(i);
+      // The top-level row object is treated slightly differently from other
+      // structs, because the field names for the row do not correctly reflect
+      // the Hive column names. For lower-level structs, we can get the field
+      // name from the associated StructField object.
+      String fieldName = isRow ? colNames.get(i) : field.getFieldName();
+      ObjectInspector fieldOI = field.getFieldObjectInspector();
+      Object fieldObj = structOI.getStructFieldData(obj, field);
+      struct.put(fieldName, deparseObject(fieldObj, fieldOI));
     }
+    return struct;
+  }
 
-    /**
-     * Deparses a primitive type.
-     * 
-     * @param obj - Hive object to deparse
-     * @param oi - ObjectInspector for the object
-     * @return - A deparsed object
-     */
-    private Object deparsePrimitive(Object obj, PrimitiveObjectInspector primOI) {
-        return primOI.getPrimitiveJavaObject(obj);
-    }
+  /**
+* Deparses a primitive type.
+*
+* @param obj - Hive object to deparse
+* @param oi - ObjectInspector for the object
+* @return - A deparsed object
+*/
+  private Object deparsePrimitive(Object obj, PrimitiveObjectInspector primOI) {
+    return primOI.getPrimitiveJavaObject(obj);
+  }
 
-    private Object deparseMap(Object obj, MapObjectInspector mapOI) {
-        Map<Object, Object> map = new HashMap<Object, Object>();
-        ObjectInspector mapValOI = mapOI.getMapValueObjectInspector();
-        Map<?, ?> fields = mapOI.getMap(obj);
-        for (Map.Entry<?, ?> field : fields.entrySet()) {
-            Object fieldName = field.getKey();
-            Object fieldObj = field.getValue();
-            map.put(fieldName, deparseObject(fieldObj, mapValOI));
-        }
-        return map;
+  private Object deparseMap(Object obj, MapObjectInspector mapOI) {
+    Map<Object,Object> map = new HashMap<Object,Object>();
+    ObjectInspector mapValOI = mapOI.getMapValueObjectInspector();
+    Map<?,?> fields = mapOI.getMap(obj);
+    for (Map.Entry<?,?> field : fields.entrySet()) {
+      Object fieldName = field.getKey();
+      Object fieldObj = field.getValue();
+      map.put(fieldName, deparseObject(fieldObj, mapValOI));
     }
+    return map;
+  }
 
-    /**
-     * Deparses a list and its elements.
-     * 
-     * @param obj - Hive object to deparse
-     * @param oi - ObjectInspector for the object
-     * @return - A deparsed object
-     */
-    private Object deparseList(Object obj, ListObjectInspector listOI) {
-        List<Object> list = new ArrayList<Object>();
-        List<?> field = listOI.getList(obj);
-        ObjectInspector elemOI = listOI.getListElementObjectInspector();
-        for (Object elem : field) {
-            list.add(deparseObject(elem, elemOI));
-        }
-        return list;
+  /**
+* Deparses a list and its elements.
+*
+* @param obj - Hive object to deparse
+* @param oi - ObjectInspector for the object
+* @return - A deparsed object
+*/
+  private Object deparseList(Object obj, ListObjectInspector listOI) {
+    List<Object> list = new ArrayList<Object>();
+    List<?> field = listOI.getList(obj);
+    ObjectInspector elemOI = listOI.getListElementObjectInspector();
+    for (Object elem : field) {
+      list.add(deparseObject(elem, elemOI));
     }
+    return list;
+  }
 }

--- a/hive-serdes/src/test/java/com/cloudera/hive/serde/TestDeserializeJSON.java
+++ b/hive-serdes/src/test/java/com/cloudera/hive/serde/TestDeserializeJSON.java
@@ -1,0 +1,37 @@
+package com.cloudera.hive.serde;
+import static org.junit.Assert.*;
+
+import java.util.Properties;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.serde.serdeConstants;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class TestDeserializeJSON {
+
+    private JSONSerDe jsonSerDe;
+    
+    /*
+    CREATE TABLE playtime_start (
+        uid STRING,generator STRING,faction STRING,level STRING,pid STRING,time STRING,gearscore STRING,event STRING
+    )
+    */
+    @Before
+    public void setUp() throws Exception {
+        jsonSerDe = new JSONSerDe();
+        
+        // init
+        Configuration testConfig = new Configuration();
+        Properties properties = new Properties();
+        properties.setProperty(serdeConstants.LIST_COLUMNS, "uid,generator,faction,level,pid,time,gearscore,event");
+        properties.setProperty(serdeConstants.LIST_COLUMN_TYPES, "string,string,string,string,string,string,string,string");
+        jsonSerDe.initialize(testConfig, properties);
+    }
+
+    @Test
+    public void test() {
+        fail("Not yet implemented");
+    }
+}

--- a/hive-serdes/src/test/java/com/cloudera/hive/serde/TestDeserializeJSON.java
+++ b/hive-serdes/src/test/java/com/cloudera/hive/serde/TestDeserializeJSON.java
@@ -41,7 +41,7 @@ public class TestDeserializeJSON {
         // init
         Configuration testConfig = new Configuration();
         Properties properties = new Properties();
-        properties.setProperty(serdeConstants.LIST_COLUMNS, "position.x,position.y,uid,pid,time,event");
+        properties.setProperty(serdeConstants.LIST_COLUMNS, "position_x,position_y,uid,pid,time,event");
         properties.setProperty(serdeConstants.LIST_COLUMN_TYPES, "int,int,int,tinyint,bigint,string");
         jsonSerDe.initialize(testConfig, properties);
     }
@@ -52,6 +52,8 @@ public class TestDeserializeJSON {
         
         Assert.assertNotNull(result);
         for (Object element : result) {
+            Assert.assertNotNull(element);
+            
             System.out.println(element.getClass().getSimpleName()+ ": "+ element.toString());
         }
     }

--- a/hive-serdes/src/test/java/com/cloudera/hive/serde/TestDeserializeJSON.java
+++ b/hive-serdes/src/test/java/com/cloudera/hive/serde/TestDeserializeJSON.java
@@ -1,17 +1,17 @@
 package com.cloudera.hive.serde;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.List;
 import java.util.Properties;
 
-import junit.framework.Assert;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.io.Writable;
-import org.junit.Before;
 import org.junit.Test;
 
 
@@ -27,34 +27,57 @@ public class TestDeserializeJSON {
         }
 
         public String toString() {
-            return "{\"position.x\":1890,\"final.vc.credits\":62809152,\"position.y\":11430,\"uid\":89775688,\"generator\":\"java:1.3:srv016108:4046 java:1.3:srv016108:4046\",\"faction\":\"EIC\",\"final.ca.honour\":8622300,\"level\":19,\"pid\":674,\"gearscore.damageScore\":43869.266,\"position.area\":24,\"time\":1399940194255,\"final.rc.uridium\":4183,\"final.ca.xp\":1665637455,\"gearscore.tacticalScore\":1.045,\"gearscore\":5647.395,\"event\":\"playtime.start\",\"gearscore.hitpointsScore\":831525.0}";
+            return "{\"position.x\":1890,\"position.y\":11430,\"uid\":89775688,\"generator\":\"java:1.3:srv016108:4046 java:1.3:srv016108:4046\",\"pid\":674,\"time\":1399940194255,\"event\":\"playtime.start\"}";
         };
     };
-    
-    private JSONSerDe jsonSerDe;
 
+    @Test(expected = NullPointerException.class)
+    public void testPatchKeyNull() {
+        JSONSerDe.patchKey(null);
+    }
+
+    @Test
+    public void testPatchKeyEmpty() {
+        assertEquals("", JSONSerDe.patchKey(""));
+    }
+
+    @Test
+    public void testPatchKeyToLowerCase() {
+        assertEquals("xxx", JSONSerDe.patchKey("XxX"));
+    }
+
+    @Test
+    public void testPatchKeyReplaceMinus() {
+        assertEquals("x_x", JSONSerDe.patchKey("x-x"));
+    }
+
+    @Test
+    public void testPatchKeyReplaceDot() {
+        assertEquals("x_x", JSONSerDe.patchKey("x.x"));
+    }
+
+    @Test
+    public void testPatchKeyuntouched() {
+        assertEquals("xox", JSONSerDe.patchKey("xox"));
+    }
     
-    @Before
-    public void setUp() throws Exception {
-        jsonSerDe = new JSONSerDe();
+    @Test
+    public void testDeserializationByExample() throws SerDeException {
+        JSONSerDe jsonSerDe = new JSONSerDe();
         
         // init
         Configuration testConfig = new Configuration();
         Properties properties = new Properties();
-        properties.setProperty(serdeConstants.LIST_COLUMNS, "position_x,position_y,uid,pid,time,event");
-        properties.setProperty(serdeConstants.LIST_COLUMN_TYPES, "int,int,int,tinyint,bigint,string");
+        properties.setProperty(serdeConstants.LIST_COLUMNS, "position_x,position_y,uid,pid,time,generator,event");
+        properties.setProperty(serdeConstants.LIST_COLUMN_TYPES, "int,int,int,tinyint,bigint,string,string");
         jsonSerDe.initialize(testConfig, properties);
-    }
 
-    @Test
-    public void test() throws SerDeException {
         List<?> result = (List<?>)jsonSerDe.deserialize(EXAMPLE);
         
-        Assert.assertNotNull(result);
+        assertNotNull(result);
+        assertEquals(7, result.size());
         for (Object element : result) {
-            Assert.assertNotNull(element);
-            
-            System.out.println(element.getClass().getSimpleName()+ ": "+ element.toString());
+            assertNotNull(element);
         }
     }
 }

--- a/hive-serdes/src/test/java/com/cloudera/hive/serde/TestDeserializeJSON.java
+++ b/hive-serdes/src/test/java/com/cloudera/hive/serde/TestDeserializeJSON.java
@@ -1,23 +1,39 @@
 package com.cloudera.hive.serde;
-import static org.junit.Assert.*;
-
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.List;
 import java.util.Properties;
+
+import junit.framework.Assert;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.serde.serdeConstants;
+import org.apache.hadoop.hive.serde2.SerDeException;
+import org.apache.hadoop.io.Writable;
 import org.junit.Before;
 import org.junit.Test;
 
 
 public class TestDeserializeJSON {
 
-    private JSONSerDe jsonSerDe;
+    private static final Writable EXAMPLE = new Writable() {
+        @Override
+        public void write(DataOutput out) throws IOException {
+        }
+
+        @Override
+        public void readFields(DataInput in) throws IOException {
+        }
+
+        public String toString() {
+            return "{\"position.x\":1890,\"final.vc.credits\":62809152,\"position.y\":11430,\"uid\":89775688,\"generator\":\"java:1.3:srv016108:4046 java:1.3:srv016108:4046\",\"faction\":\"EIC\",\"final.ca.honour\":8622300,\"level\":19,\"pid\":674,\"gearscore.damageScore\":43869.266,\"position.area\":24,\"time\":1399940194255,\"final.rc.uridium\":4183,\"final.ca.xp\":1665637455,\"gearscore.tacticalScore\":1.045,\"gearscore\":5647.395,\"event\":\"playtime.start\",\"gearscore.hitpointsScore\":831525.0}";
+        };
+    };
     
-    /*
-    CREATE TABLE playtime_start (
-        uid STRING,generator STRING,faction STRING,level STRING,pid STRING,time STRING,gearscore STRING,event STRING
-    )
-    */
+    private JSONSerDe jsonSerDe;
+
+    
     @Before
     public void setUp() throws Exception {
         jsonSerDe = new JSONSerDe();
@@ -25,13 +41,18 @@ public class TestDeserializeJSON {
         // init
         Configuration testConfig = new Configuration();
         Properties properties = new Properties();
-        properties.setProperty(serdeConstants.LIST_COLUMNS, "uid,generator,faction,level,pid,time,gearscore,event");
-        properties.setProperty(serdeConstants.LIST_COLUMN_TYPES, "string,string,string,string,string,string,string,string");
+        properties.setProperty(serdeConstants.LIST_COLUMNS, "position.x,position.y,uid,pid,time,event");
+        properties.setProperty(serdeConstants.LIST_COLUMN_TYPES, "int,int,int,tinyint,bigint,string");
         jsonSerDe.initialize(testConfig, properties);
     }
 
     @Test
-    public void test() {
-        fail("Not yet implemented");
+    public void test() throws SerDeException {
+        List<?> result = (List<?>)jsonSerDe.deserialize(EXAMPLE);
+        
+        Assert.assertNotNull(result);
+        for (Object element : result) {
+            System.out.println(element.getClass().getSimpleName()+ ": "+ element.toString());
+        }
     }
 }


### PR DESCRIPTION
Because Hive SQL can not handle keys with dot or minus (e.g. dot is used as path separator at SQL) the JSON keys were patched to replace dot or minus with underline ('_').

JSON example: 
{"position.x":10,"position.y":10,"id":4711}

Hive table example:
ADD JAR /tmp/hive-serdes-1.0.1-SNAPSHOT.jar;

DROP TABLE example;
CREATE TABLE example (
  position_x INT,
  position_y INT,
  id STRING
)
ROW FORMAT SERDE 'com.cloudera.hive.serde.JSONSerDe'
LOCATION '/user/json/example/';

SELECT * from example LIMIT 10;
